### PR TITLE
Add spacing between paragraphs and remove indent

### DIFF
--- a/_sass/variables.scss
+++ b/_sass/variables.scss
@@ -8,7 +8,7 @@
 
 $doc-font-size: 16;
 $doc-line-height: 26;
-$paragraph-indent: true !default;
+$paragraph-indent: false !default;
 $base-font: 'PT Serif', serif;
 $heading-font: 'PT Sans Narrow', sans-serif;
 $code-font: Monaco, "Courier New", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", monospace;


### PR DESCRIPTION
The theme has a variable called paragraph-indent. Setting this to false
gives better formatting for blogs in my opinion