### PR TITLE
Remove categories from the post URLs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ excerpt_separator: <!--more-->
 
 # Jekyll configuration
 
-permalink:   /:categories/:title/
+permalink:   /:title/
 markdown:    kramdown
 highlighter: pygments
 sass:


### PR DESCRIPTION
I find this cleaner, especially when there are multiple categories on a post.  Changes from:

http://www.westerndevs.com/slack,discussion/discussion-hosting-git-in-house/
to
http://www.westerndevs.com/discussion-hosting-git-in-house/

Will also remove /podcasts/ from URL.