### PR TITLE
Added syntax highlighting from the base hexo light theme

### DIFF
--- a/themes/westerndevs/source/css/_partial/syntax.styl
+++ b/themes/westerndevs/source/css/_partial/syntax.styl
@@ -1,0 +1,146 @@
+.entry
+  .gist
+    background #eee
+    border 1px solid color-border
+    margin-top 15px
+    padding 7px 15px
+    border-radius 2px
+    text-shadow 0 0 1px #fff
+    line-height 1.6
+    overflow auto
+    color #666
+    .gist-file
+      border none
+      font-family inherit
+      margin 0
+      font-size 0.9em
+      .gist-data
+        background none
+        border-bottom none
+        pre
+          padding 0 !important
+          font-family font-mono
+      .gist-meta
+        background none
+        color color-meta
+        margin-top 5px
+        padding 0
+        text-shadow 0 0 1px #fff
+        font-size 100%
+        a
+          color color-link
+          &:visited
+            color color-link
+
+figure.highlight
+  background #eee
+  border 1px solid color-border
+  margin-top 15px
+  padding 7px 15px
+  border-radius 2px
+  text-shadow 0 0 1px #fff
+  line-height 1.6
+  overflow auto
+  position relative
+  font-size 0.9em
+  figcaption
+    color color-meta
+    margin-bottom 5px
+    text-shadow 0 0 1px #fff
+    a
+      position absolute
+      right 15px
+
+  pre
+    border none
+    padding 0
+    margin 0
+
+  table
+    margin-top 0
+    border-spacing 0
+
+  .gutter
+    color color-meta
+    padding-right 15px
+    border-right 1px solid color-border
+    text-align right
+
+  .code
+    padding-left 15px
+    border-left 1px solid #fff
+    color #666
+
+  .line
+    height: 20px
+
+pre
+  // Theme: Solarized - Light
+  // More theme here: http://softwaremaniacs.org/media/soft/highlight/test.html
+  .comment
+  .template_comment
+  .diff .header
+  .doctype
+  .pi
+  .lisp .string
+  .javadoc
+    color #93a1a1
+    font-style italic
+
+  .keyword
+  .winutils
+  .method
+  .addition
+  .css .tag
+  .request
+  .status
+  .nginx .title
+    color #859900
+
+  .number
+  .command
+  .string
+  .tag .value
+  .phpdoc
+  .tex .formula
+  .regexp
+  .hexcolor
+    color #2aa198
+
+  .title
+  .localvars
+  .chunk
+  .decorator
+  .built_in
+  .identifier
+  .vhdl
+  .literal
+  .id
+    color #268bd2
+
+  .attribute
+  .variable
+  .lisp .body
+  .smalltalk .number
+  .constant
+  .class .title
+  .parent
+  .haskell .type
+    color #b58900
+
+  .preprocessor
+  .preprocessor .keyword
+  .shebang
+  .symbol
+  .symbol .string
+  .diff .change
+  .special
+  .attr_selector
+  .important
+  .subst
+  .cdata
+  .clojure .title
+    color #cb4b16
+
+  .deletion
+    color #dc322f

--- a/themes/westerndevs/source/css/style.styl
+++ b/themes/westerndevs/source/css/style.styl
@@ -580,3 +580,5 @@ li
 
 .podcast-content h3:not(:first-child), .podcast-content h4:not(:first-child)
   padding-top 10px
+  
+ @import '_partial/syntax'


### PR DESCRIPTION
Looks like this. We can tweak the background colour if we want.

![image](https://cloud.githubusercontent.com/assets/2531875/11723664/8860256a-9f3d-11e5-887b-b2f602922266.png)

Let me know if I should tweak the colour.
