### PR TITLE
Making the header fixed

### DIFF
--- a/themes/westerndevs/layout/layout.ejs
+++ b/themes/westerndevs/layout/layout.ejs
@@ -5,11 +5,11 @@
 
 <body leftmargin="0" topmargin="0" marginheight="0" marginwidth="0" rightmargin="0">
 
+<!-- FIXED HEADER BECAUSE SCROLLING -->
+<%- partial('_partial/header') %>
 
 <!--WRAPPER STARTS--> 
 <div class="Wrapper">
-
-<%- partial('_partial/header') %>
 
 <%- body %>
 

--- a/themes/westerndevs/source/css/style.styl
+++ b/themes/westerndevs/source/css/style.styl
@@ -66,6 +66,7 @@ BODY
   background-repeat no-repeat
   background-image URL('/images/bg.jpg')
   background-position top center
+  margin-top:100px
 
 A:LINK, A:ACTIVE, A:VISITED, A:HOVER
   COLOR #0e76bc
@@ -121,7 +122,9 @@ A.subposts:LINK, A.subposts:ACTIVE, A.subposts:VISITED, A.subposts:HOVER
   text-align left
 
 .WrapperHeader
-  position relative
+  position fixed 
+  top 0px
+  z-index 1000
   display block
   width 100%
   min-width 1024px


### PR DESCRIPTION
I didn't like the way our header was scrolling. If you started moving down the page you were like, "where am I?"

Maybe it was just me. But here is a PR.

- updated styles for header
- moved the header out of the wrapper to the root of the body

Now it does this:
![image](https://cloud.githubusercontent.com/assets/1197383/11911912/2fda3dc6-a5ec-11e5-8c04-d44db86c2349.png)
