### PR TITLE
Update to Author Sidebar

### DIFF
--- a/themes/westerndevs/layout/_widget/author_sidebar.ejs
+++ b/themes/westerndevs/layout/_widget/author_sidebar.ejs
@@ -32,7 +32,9 @@
 			<a href="https://www.linkedin.com/in/<%=author.linkedin%>" target="_blank"><img class="ProfileIcon" src="/images/icon_linkedin.png" border="0" alt="LinkedIN" title="LinkedIN"> LinkedIn</a>
 			<% } %>
 			
-		
+			<hr />
+			<h4>Looking for someone else?</h4>
+			<p>You can find the rest of the Western Devs Crew <a href="/whoweare">here</a>.</p>
 		</div>
 	</div>
 <!--SIDEBAR CONTENT ENDS-->	


### PR DESCRIPTION
I think that we should be able to navigate back to the author list from any other author. When you click on one, you lose the list. I don't think we should all be on every page, but I think we should be able to get back to the list easily enough.

- added link to the about us page

Looks like this:
![image](https://cloud.githubusercontent.com/assets/1197383/11911937/31a6aeea-a5ed-11e5-90eb-6d7201d3dfd5.png)

