### PR TITLE
added json content generator

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -95,3 +95,28 @@ feed:
   itunespath: itunes.xml
   limit: 20
   hub:
+
+# JSON
+## https://github.com/alexbruno/hexo-generator-json-content
+jsonContent:
+  meta: true
+  keywords: false # language name option
+  dateFormat: YYYY-MM-DD HH:mm:ssZZ # format string
+  posts:
+    title: true
+    authorId: true
+    slug: true
+    date: true
+    updated: true
+    comments: true
+    path: true
+    link: true
+    permalink: true
+    excerpt: true
+    keywords: true # but only if root keywords option language was set
+    text: false
+    raw: false
+    content: false
+    categories: true
+    tags: true
+  pages: false

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "hexo": {
-    "version": "3.3.7"
+    "version": "3.3.9"
   },
   "engines": {
     "node": ">=6.11.2"
@@ -17,6 +17,7 @@
     "hexo-generator-category": "^0.1.2",
     "hexo-generator-feed-westerndevs": "git+https://github.com/westerndevs/hexo-generator-feed.git",
     "hexo-generator-index": "^0.1.2",
+    "hexo-generator-json-content": "^3.0.1",
     "hexo-generator-seo-friendly-sitemap": "0.0.11",
     "hexo-generator-tag": "^0.1.1",
     "hexo-multiauthor": "0.0.1",


### PR DESCRIPTION
I've added a content generator that will produce a JSON file that contains all the content. I'd like this to be available in the public site, so that I can do a few side experiments with our blog data.