### PR TITLE
set default category to underscore if category is missing. 

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,8 +16,6 @@ email: info@westerndevs.com
 url: https://westerndevs.com
 root: /
 permalink: :category/:title/
-permalink_defaults:
-  categories: ""
 
 # Directory
 source_dir: source
@@ -46,7 +44,7 @@ highlight:
   tab_replace:
 
 # Category & Tag
-default_category: ''
+default_category: '_'
 category_map:
 tag_map:
 


### PR DESCRIPTION
Set the `default_category` in the config to use an underscore. Puts something in the RSS feed so that the links don't break, although it will change all the URLs for those that don't have categories.

@stimms posts from November 5 both are missing categories, if you're looking for examples.

resolves #226